### PR TITLE
Update url to point to requirements meaning

### DIFF
--- a/checks/requirements
+++ b/checks/requirements
@@ -1,5 +1,5 @@
 #!/bin/bash
-URL="https://hacs.xyz/docs/publish/include#check-requirements"
+URL="https://github.com/hacs/action#ignorable-checks"
 GROUP="requirements"
 
 function checkCondition () {


### PR DESCRIPTION
This may not be the most ideal link but at least it describes what the check is doing. Alternatively, you can a section back to the other page.

closes https://github.com/hacs/integration/issues/2297